### PR TITLE
Display mock entries on dashboard

### DIFF
--- a/src/components/JournalEntryCard/JournalEntryCard.css
+++ b/src/components/JournalEntryCard/JournalEntryCard.css
@@ -2,6 +2,7 @@
     border: 1px solid grey;
     border-radius: 10px;
     padding: 10px;
+    max-width: 300px;
 }
 
 .journal-entry-card-options {

--- a/src/components/JournalEntryCard/JournalEntryCard.css
+++ b/src/components/JournalEntryCard/JournalEntryCard.css
@@ -2,11 +2,12 @@
     border: 1px solid grey;
     border-radius: 10px;
     padding: 10px;
-    max-width: 300px;
+    width: 300px;
+    margin: 10px;
 }
 
 .journal-entry-card-options {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
+    justify-content: space-evenly;
 }

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
 import moment from 'moment';
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
 import './JournalEntryCard.css';
 
 interface mockData {
@@ -21,20 +23,22 @@ interface JournalEntryCardProps {
 
 const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
   const { entry } = props;
+
   return (
     <Box className="journal-entry-card">
-        <Typography variant="h5">Entry Date: {moment(entry.date).format("MMMM Do YYYY")}</Typography>
-        <Typography variant="body1">Amount of water you drank: {entry.waterIntake}oz</Typography>
-        <Typography variant="body1">Amount of protein you had: {entry.proteinIntake}g</Typography>
-        <Typography variant="body1">How long you exercised for: {entry.exercise}min</Typography>
-        <Typography variant="body1">How many kegels you did: {entry.kegels}</Typography>
-        <Typography variant="body1">How long you did garland pose for: {entry.garlandPose}min</Typography>
-        <Typography variant="body1">Did you take your prenatal vitamins? {entry.prenatalVitamins ? 'yes' : 'no'}</Typography>
-        <Typography variant="body1">Did you take your probiotics? {entry.probiotics ? 'yes' : 'no'}</Typography>
-        <Box className="journal-entry-card-options">
-            <Button color="inherit" variant="outlined">Delete Entry</Button>
-            <Button color="inherit" variant="outlined">Edit Entry</Button> 
-        </Box>
+        
+      <Typography variant="h5">{moment(entry.date).format("MMMM Do YYYY")}</Typography>
+      <Typography variant="body1">You drank <b>{entry.waterIntake}oz</b> of water</Typography>
+      <Typography variant="body1">You had <b>{entry.proteinIntake}g</b> of protein</Typography>
+      <Typography variant="body1">You exercised for <b>{entry.exercise} minute{entry.exercise === 1 ? '' : 's'}</b></Typography>
+      <Typography variant="body1">You did <b>{entry.kegels} kegel{entry.kegels === 1 ? '' : 's'}</b></Typography>
+      <Typography variant="body1">You did garland pose for <b>{entry.garlandPose} minute{entry.garlandPose === 1 ? '' : 's'}</b></Typography>
+      <Typography variant="body1">You <b>{entry.prenatalVitamins ? 'did' : 'did not'}</b> take your prenatal vitamins </Typography>
+      <Typography variant="body1">You <b>{entry.probiotics ? 'did' : 'did not'}</b> take your probiotics </Typography>
+      <Box className="journal-entry-card-options">
+          <IconButton color="warning"><DeleteIcon /></IconButton>
+          <IconButton color="default"><EditIcon /></IconButton> 
+      </Box>
     </Box>
   )
 }

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -2,25 +2,39 @@ import React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import moment from 'moment';
 import './JournalEntryCard.css';
 
+interface mockData {
+  date: string;
+  waterIntake: number;
+  proteinIntake: number;
+  exercise: number;
+  kegels: number;
+  garlandPose: number;
+  prenatalVitamins: boolean;
+  probiotics: boolean;
+}
+interface JournalEntryCardProps {
+  entry: mockData;
+}
 
-const JournalEntryCard = () => {
+const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
+  const { entry } = props;
   return (
     <Box className="journal-entry-card">
-        <Typography variant="h5">Entry Date</Typography>
-        <Typography variant="body1">Amount of water you drank: </Typography>
-        <Typography variant="body1">Amount of protein you had: </Typography>
-        <Typography variant="body1">How long you exercised for: </Typography>
-        <Typography variant="body1">How many kegels you did: </Typography>
-        <Typography variant="body1">How long you did garland pose for: </Typography>
-        <Typography variant="body1">Did you take your prenatal vitamins? </Typography>
-        <Typography variant="body1">Did you take your probiotics? </Typography>
+        <Typography variant="h5">Entry Date: {moment(entry.date).format("MMMM Do YYYY")}</Typography>
+        <Typography variant="body1">Amount of water you drank: {entry.waterIntake}oz</Typography>
+        <Typography variant="body1">Amount of protein you had: {entry.proteinIntake}g</Typography>
+        <Typography variant="body1">How long you exercised for: {entry.exercise}min</Typography>
+        <Typography variant="body1">How many kegels you did: {entry.kegels}</Typography>
+        <Typography variant="body1">How long you did garland pose for: {entry.garlandPose}min</Typography>
+        <Typography variant="body1">Did you take your prenatal vitamins? {entry.prenatalVitamins ? 'yes' : 'no'}</Typography>
+        <Typography variant="body1">Did you take your probiotics? {entry.probiotics ? 'yes' : 'no'}</Typography>
         <Box className="journal-entry-card-options">
             <Button color="inherit" variant="outlined">Delete Entry</Button>
             <Button color="inherit" variant="outlined">Edit Entry</Button> 
         </Box>
-        
     </Box>
   )
 }

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -27,7 +27,7 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
   return (
     <Box className="journal-entry-card">
         
-      <Typography variant="h5">{moment(entry.date).format("MMMM Do YYYY")}</Typography>
+      <Typography variant="h5"><b>{moment(entry.date).format("MMMM Do YYYY")}</b></Typography>
       <Typography variant="body1">You drank <b>{entry.waterIntake}oz</b> of water</Typography>
       <Typography variant="body1">You had <b>{entry.proteinIntake}g</b> of protein</Typography>
       <Typography variant="body1">You exercised for <b>{entry.exercise} minute{entry.exercise === 1 ? '' : 's'}</b></Typography>

--- a/src/pages/DashboardPage/DashboardPage.css
+++ b/src/pages/DashboardPage/DashboardPage.css
@@ -2,9 +2,11 @@
     display: flex;
     flex-direction: column;
     text-align: center;
+    align-items: center;
 }
 
 .dashboard-journal-entries-container {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
 }

--- a/src/pages/DashboardPage/DashboardPage.css
+++ b/src/pages/DashboardPage/DashboardPage.css
@@ -3,3 +3,8 @@
     flex-direction: column;
     text-align: center;
 }
+
+.dashboard-journal-entries-container {
+    display: flex;
+    flex-wrap: wrap;
+}

--- a/src/pages/DashboardPage/DashboardPage.css
+++ b/src/pages/DashboardPage/DashboardPage.css
@@ -1,4 +1,5 @@
 .dashboard-main {
     display: flex;
-    
+    flex-direction: column;
+    text-align: center;
 }

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -2,15 +2,75 @@ import React, { useContext } from 'react';
 import { AuthContext } from '../../shared/auth-context';
 import MessagePage from '../../components/MessagePage/MessagePage';
 import JournalEntryCard from '../../components/JournalEntryCard/JournalEntryCard';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import moment from 'moment';
 
 import './DashboardPage.css';
+
+interface mockData {
+    date: string;
+    waterIntake: number;
+    proteinIntake: number;
+    exercise: number;
+    kegels: number;
+    garlandPose: number;
+    prenatalVitamins: boolean;
+    probiotics: boolean;
+}
+
+const mockEntries: mockData[]= [
+    {
+       "date": "2022-03-07T19:58:57.000Z",
+       "waterIntake": 1,
+       "proteinIntake": 1,
+       "exercise": 1,
+       "kegels": 1,
+       "garlandPose": 1,
+       "prenatalVitamins": true,
+       "probiotics": true 
+    },
+    {
+        "date": "2022-03-08T19:58:57.000Z",
+        "waterIntake": 2,
+        "proteinIntake": 2,
+        "exercise": 2,
+        "kegels": 2,
+        "garlandPose": 2,
+        "prenatalVitamins": true,
+        "probiotics": false
+     },
+     {
+        "date": "2022-03-09T19:58:57.000Z",
+        "waterIntake": 3,
+        "proteinIntake": 3,
+        "exercise": 3,
+        "kegels": 3,
+        "garlandPose": 3,
+        "prenatalVitamins": false,
+        "probiotics": false
+     },
+     {
+        "date": "2022-03-10T19:58:57.000Z",
+        "waterIntake": 4,
+        "proteinIntake": 4,
+        "exercise": 4,
+        "kegels": 4,
+        "garlandPose": 4,
+        "prenatalVitamins": true,
+        "probiotics": true 
+     },
+]
 
 const DashboardPage = () => {
     const user = useContext(AuthContext);
 
     return user.isLoggedIn ? (
         <main className="dashboard-main">
-            <JournalEntryCard />
+            <Typography variant="h5">Welcome back {user.displayName}!</Typography>
+            <Box>
+                <JournalEntryCard />
+            </Box>
         </main>
     ) : (
         <MessagePage 

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -4,7 +4,6 @@ import MessagePage from '../../components/MessagePage/MessagePage';
 import JournalEntryCard from '../../components/JournalEntryCard/JournalEntryCard';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import moment from 'moment';
 
 import './DashboardPage.css';
 
@@ -68,8 +67,10 @@ const DashboardPage = () => {
     return user.isLoggedIn ? (
         <main className="dashboard-main">
             <Typography variant="h5">Welcome back {user.displayName}!</Typography>
-            <Box>
-                <JournalEntryCard />
+            <Box className='dashboard-journal-entries-container'>
+                {mockEntries.map((entry: mockData) => {
+                   return <JournalEntryCard entry={entry} key={entry.waterIntake}/>
+                })}  
             </Box>
         </main>
     ) : (

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -66,7 +66,7 @@ const DashboardPage = () => {
 
     return user.isLoggedIn ? (
         <main className="dashboard-main">
-            <Typography variant="h5">Welcome back {user.displayName}!</Typography>
+            <Typography variant="h2">Welcome back {user.displayName}!</Typography>
             <Box className='dashboard-journal-entries-container'>
                 {mockEntries.map((entry: mockData) => {
                    return <JournalEntryCard entry={entry} key={entry.waterIntake}/>

--- a/src/pages/NewEntryFormPage/NewEntryFormPage.tsx
+++ b/src/pages/NewEntryFormPage/NewEntryFormPage.tsx
@@ -27,14 +27,14 @@ const NewEntryFormPage: React.FC = () => {
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        console.log(moment(date).toString())
-        console.log(waterIntake)
-        console.log(proteinIntake)
-        console.log(exercise)
-        console.log(kegels)
-        console.log(garlandPose)
-        console.log(prenatalVitamins)
-        console.log(probiotics)
+        console.log(moment(date).toISOString())
+        // console.log(waterIntake)
+        // console.log(proteinIntake)
+        // console.log(exercise)
+        // console.log(kegels)
+        // console.log(garlandPose)
+        // console.log(prenatalVitamins)
+        // console.log(probiotics)
     }
 
     return user.isLoggedIn ? (


### PR DESCRIPTION
What this PR does:
- Creates mock entry data that passes to JournalEntryCard through a map iterator which then displays the JournalEntryCards on the DashboardPage
- Changes the Edit and Delete buttons on the JournalEntryCard to be IconButtons from MUI
- Adds some small styling touches to the DashboardPage and JournalEntryCard