### PR TITLE
Include user id mock journal entries, conditionally render journal entries on dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ const App = () => {
     <AuthContext.Provider 
       value={{
         isLoggedIn: isLoggedIn,
-        userId: userId,
+        id: userId,
         displayName: displayName,
         photoURL: photoURL
       }}

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -9,19 +9,9 @@ import WarningModal from '../WarningModal/WarningModal';
 import { SnackBar, SnackBarDetails } from '../SnackBar/SnackBar';
 import { Alert } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
+import { mockData } from '../../pages/DashboardPage/DashboardPage';
 import './JournalEntryCard.css';
 
-interface mockData {
-  id: number;
-  date: string;
-  waterIntake: number;
-  proteinIntake: number;
-  exercise: number;
-  kegels: number;
-  garlandPose: number;
-  prenatalVitamins: boolean;
-  probiotics: boolean;
-}
 interface JournalEntryCardProps {
   entry: mockData;
 }

--- a/src/pages/DashboardPage/DashboardPage.css
+++ b/src/pages/DashboardPage/DashboardPage.css
@@ -10,3 +10,13 @@
     flex-wrap: wrap;
     justify-content: center;
 }
+
+.dashboard-no-entries-container {
+    display: flex;
+    flex-direction: column;
+    max-width: min(80ch, 100%);
+}
+
+.dashboard-create-journal-entry-button-container {
+    margin-top: 15px;;
+}

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -4,6 +4,9 @@ import MessagePage from '../../components/MessagePage/MessagePage';
 import JournalEntryCard from '../../components/JournalEntryCard/JournalEntryCard';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { useNavigate } from 'react-router-dom';
+import Button from '@mui/material/Button';
+import { PossibleRoutes } from '../../utils/constants';
 
 import './DashboardPage.css';
 
@@ -73,15 +76,39 @@ export const mockEntries: mockData[]= [
 
 const DashboardPage = () => {
     const user = useContext(AuthContext);
+    const navigate = useNavigate();
+    const foundEntries = 
+        mockEntries.filter((entry: mockData) => {
+            return user.id === entry.userId
+        }
+    )
+
+    const handleNavigateToJournalEntryForm = (callback: () => void) => {
+        return () => {
+            callback()
+        }
+    }
 
     return user.isLoggedIn ? (
         <main className="dashboard-main">
             <Typography variant="h2">Welcome back {user.displayName}!</Typography>
-            <Box className='dashboard-journal-entries-container'>
-                {mockEntries.map((entry: mockData) => {
-                   return <JournalEntryCard entry={entry} key={entry.id}/>
-                })}  
-            </Box>
+            {foundEntries.length ? 
+            (
+                <Box className='dashboard-journal-entries-container'>
+                    {foundEntries.map((entry: mockData) => {
+                        return <JournalEntryCard entry={entry} key={entry.id}/>
+                    })}
+                </Box>
+            ) : (
+                <Box className='dashboard-no-entries-container'>
+                    <Typography variant="h6">Looks like you don't have any journal entries yet. Click the button below to create your first entry!</Typography>
+                    <Box className='dashboard-create-journal-entry-button-container'>
+                        <Button onClick={handleNavigateToJournalEntryForm(() => navigate(PossibleRoutes.JOURNAL_ENTRY_FORM))} variant='contained' color='success'>
+                            <Typography variant="body1">New Journal Entry</Typography>
+                        </Button>
+                    </Box>
+                </Box>
+            )}
         </main>
     ) : (
         <MessagePage 

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -9,6 +9,7 @@ import './DashboardPage.css';
 
 export interface mockData {
     id: number;
+    userId: string;
     date: string;
     waterIntake: number;
     proteinIntake: number;
@@ -22,17 +23,19 @@ export interface mockData {
 export const mockEntries: mockData[]= [
     {
         "id": 1,
-       "date": "2022-03-07T19:58:57.000Z",
-       "waterIntake": 1,
-       "proteinIntake": 1,
-       "exercise": 1,
-       "kegels": 1,
-       "garlandPose": 1,
-       "prenatalVitamins": true,
-       "probiotics": true 
+        "userId": "fV5De0bivMRqBoHxJuwT4UwFJtT2",
+        "date": "2022-03-07T19:58:57.000Z",
+        "waterIntake": 1,
+        "proteinIntake": 1,
+        "exercise": 1,
+        "kegels": 1,
+        "garlandPose": 1,
+        "prenatalVitamins": true,
+        "probiotics": true 
     },
     {
         "id": 2,
+        "userId": "fV5De0bivMRqBoHxJuwT4UwFJtT2",
         "date": "2022-03-08T19:58:57.000Z",
         "waterIntake": 2,
         "proteinIntake": 2,
@@ -44,6 +47,7 @@ export const mockEntries: mockData[]= [
      },
      {
         "id": 3,
+        "userId": "fV5De0bivMRqBoHxJuwT4UwFJtT2",
         "date": "2022-03-09T19:58:57.000Z",
         "waterIntake": 3,
         "proteinIntake": 3,
@@ -55,6 +59,7 @@ export const mockEntries: mockData[]= [
      },
      {
         "id": 4,
+        "userId": "fV5De0bivMRqBoHxJuwT4UwFJtT2",
         "date": "2022-03-10T19:58:57.000Z",
         "waterIntake": 4,
         "proteinIntake": 4,

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -59,7 +59,7 @@ export const mockEntries: mockData[]= [
      },
      {
         "id": 4,
-        "userId": "fV5De0bivMRqBoHxJuwT4UwFJtT2",
+        "userId": "DRYvbhpN9UPqJPcbKV21TH3Yp8N2",
         "date": "2022-03-10T19:58:57.000Z",
         "waterIntake": 4,
         "proteinIntake": 4,

--- a/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
+++ b/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
@@ -187,8 +187,8 @@ const JournalEntryFormPage: React.FC = () => {
         </main>
     ) : (
         <MessagePage 
-            title="Uh oh, looks like you're not logged in."
-            subtitle="You must be logged-in to view this page."
+            title="Uh oh, looks like you don't have the right credentials for this page."
+            subtitle="You must be logged-in to the correct account to view this page."
         />
     )
 }

--- a/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
+++ b/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
@@ -58,7 +58,7 @@ const JournalEntryFormPage: React.FC = () => {
         if (entryId) {
             foundEntry = mockEntries.find(entry => entry.id === parseInt(entryId)) 
         } 
-        if (foundEntry && user.userId === foundEntry.userId) {
+        if (foundEntry && user.id === foundEntry.userId) {
             setDate(foundEntry.date)
             setEntryUserId(foundEntry.userId)
             setWaterIntake(foundEntry.waterIntake)
@@ -83,9 +83,9 @@ const JournalEntryFormPage: React.FC = () => {
             setTitle('Create A New Journal Entry')
             setDescription('Fill out the form below and save changes to create a new journal entry.')
         }
-    }, [entryId, user.userId])
+    }, [entryId, user.id])
 
-    return (user.userId === entryUserId || entryId === undefined) ? (
+    return (user.id === entryUserId || entryId === undefined) ? (
         <main>
             <form className="form" onSubmit={handleSubmit}>
                 <Typography variant='h5' className="page-title">{title}</Typography>

--- a/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
+++ b/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
@@ -23,6 +23,7 @@ const JournalEntryFormPage: React.FC = () => {
     const user = useContext(AuthContext);
     const navigate = useNavigate();
     const { entryId } = useParams();
+    const [entryUserId, setEntryUserId] = useState<string | null>(null)
     const [date, setDate] = useState<string | null>(null);
     const [waterIntake, setWaterIntake] = useState<number | string>('');
     const [proteinIntake, setProteinIntake] = useState<number | string>('');
@@ -53,22 +54,25 @@ const JournalEntryFormPage: React.FC = () => {
     }
 
     useEffect(() => {
+        let foundEntry;
         if (entryId) {
-            const foundEntry = mockEntries.find(entry => entry.id === parseInt(entryId)) 
-            if (foundEntry) {
-                setDate(foundEntry.date)
-                setWaterIntake(foundEntry.waterIntake)
-                setProteinIntake(foundEntry.proteinIntake)
-                setExercise(foundEntry.exercise)
-                setKegels(foundEntry.kegels)
-                setGarlandPose(foundEntry.garlandPose)
-                setPrenatalVitamins(foundEntry.prenatalVitamins)
-                setProbiotics(foundEntry.probiotics)
-                setTitle('Update Journal Entry')
-                setDescription('Update the form below and save changes to your journal entry.')
-            }
+            foundEntry = mockEntries.find(entry => entry.id === parseInt(entryId)) 
+        } 
+        if (foundEntry && user.userId === foundEntry.userId) {
+            setDate(foundEntry.date)
+            setEntryUserId(foundEntry.userId)
+            setWaterIntake(foundEntry.waterIntake)
+            setProteinIntake(foundEntry.proteinIntake)
+            setExercise(foundEntry.exercise)
+            setKegels(foundEntry.kegels)
+            setGarlandPose(foundEntry.garlandPose)
+            setPrenatalVitamins(foundEntry.prenatalVitamins)
+            setProbiotics(foundEntry.probiotics)
+            setTitle('Update Journal Entry')
+            setDescription('Update the form below and save changes to your journal entry.')
         } else {
             setDate(null)
+            setEntryUserId(null)
             setWaterIntake('')
             setProteinIntake('')
             setExercise('')
@@ -79,9 +83,9 @@ const JournalEntryFormPage: React.FC = () => {
             setTitle('Create A New Journal Entry')
             setDescription('Fill out the form below and save changes to create a new journal entry.')
         }
-    }, [entryId])
+    }, [entryId, user.userId])
 
-    return user.isLoggedIn ? (
+    return (user.userId === entryUserId || entryId === undefined) ? (
         <main>
             <form className="form" onSubmit={handleSubmit}>
                 <Typography variant='h5' className="page-title">{title}</Typography>

--- a/src/shared/auth-context.ts
+++ b/src/shared/auth-context.ts
@@ -2,14 +2,14 @@ import { createContext } from "react";
 
 export interface User {
     isLoggedIn: boolean;
-    userId: string | null;
+    id: string | null;
     displayName: string | null;
     photoURL: string | null;
 }
 
 export const AuthContext = createContext<User>({ 
     isLoggedIn: false, 
-    userId: null,
+    id: null,
     displayName: '',
     photoURL: ''
 })


### PR DESCRIPTION
What this PR does:
- Add userId to mock journal entry data
- If user.id doesn't match entry.userId then a message page displays a message that the user doesn't have the correct credentials for that page.
- Conditionally render the journal entry cards to only contain the user's entries, if none found message displayed to direct user to the Journal Entry Form to create one