### PR TITLE
Feature delete entry, and update dashboard on delete or 

### DIFF
--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -176,5 +176,5 @@ export const deleteJournalEntry = async (id: number) => {
     variables: { where: { id: Number(id) } }
   });
 
-  return data ? 'Deleted successfully' : 'Error while deleting';
+  return data.deleteJournalEntry;
 };

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -30,7 +30,7 @@ export const useJournalEntry = (id: string) => {
   });
 };
 
-const createJournalEntryQuery = gql`
+const createJournalEntryMutation = gql`
   mutation createJournalEntry($data: JournalEntryCreateInput!){
     createJournalEntry(
       data: $data
@@ -60,7 +60,7 @@ interface JournalEntryCreate {
   probiotics: boolean | null;
 }
 
-export const createJournalEntryMutation = async (createJournalEntryInput: JournalEntryCreate) => {
+const createJournalEntry = async (createJournalEntryInput: JournalEntryCreate) => {
   const { 
     date, 
     exercise, 
@@ -90,13 +90,21 @@ export const createJournalEntryMutation = async (createJournalEntryInput: Journa
   };
 
   const { data } = await API.mutate<any>({
-    mutation: createJournalEntryQuery,
+    mutation: createJournalEntryMutation,
     variables: { data: variables}
   });
-
-  console.log(data)
   
-  return data;
+  return data.createJournalEntry;
+}
+
+export const useCreateJournalEntry = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(createJournalEntry, {
+    onSuccess: () => {
+      queryClient.invalidateQueries("journalEntries")
+    }
+  })
 }
 
 interface JournalEntryUpdate {

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -30,7 +30,7 @@ export const useJournalEntry = (id: string) => {
   });
 };
 
-const createJournalEntryQuery = `
+const createJournalEntryQuery = gql`
   mutation createJournalEntry($data: JournalEntryCreateInput!){
     createJournalEntry(
       data: $data
@@ -60,7 +60,7 @@ interface JournalEntryCreate {
   probiotics: boolean | null;
 }
 
-export const createJournalEntry = async (createJournalEntryInput: JournalEntryCreate) => {
+export const createJournalEntryMutation = async (createJournalEntryInput: JournalEntryCreate) => {
   const { 
     date, 
     exercise, 
@@ -90,12 +90,14 @@ export const createJournalEntry = async (createJournalEntryInput: JournalEntryCr
   };
 
   const { data } = await API.mutate<any>({
-    mutation: gql(createJournalEntryQuery),
+    mutation: createJournalEntryQuery,
     variables: { data: variables}
   });
+
+  console.log(data)
   
-  return data.createJournalEntry;
-};
+  return data;
+}
 
 interface JournalEntryUpdate {
   id: string | undefined;

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -118,14 +118,14 @@ const updateJournalEntryQuery = `
     where: $where
   ) {
     date
-      exercise
-      garlandPose
-      kegels
-      prenatalVitamins
-      probiotics
-      proteinIntake
-      waterIntake
-      authorId
+    exercise
+    garlandPose
+    kegels
+    prenatalVitamins
+    probiotics
+    proteinIntake
+    waterIntake
+    authorId
     }
   }
 `;
@@ -158,6 +158,23 @@ export const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUp
     mutation: gql(updateJournalEntryQuery),
     variables: { data: variables, where: { id: Number(id) }}
   });
-  
+
   return data.updateJournalEntry;
 }
+
+const deleteJournalEntryQuery = `
+  mutation deleteJournalEntry($where: JournalEntryWhereUniqueInput!) {
+    deleteJournalEntry(where: $where) {
+      id
+    }
+  }
+`
+
+export const deleteJournalEntry = async (id: number) => {
+  const { data } = await API.mutate<any>({
+    mutation: gql(deleteJournalEntryQuery),
+    variables: { where: { id: Number(id) } }
+  });
+
+  return data ? 'Deleted successfully' : 'Error while deleting';
+};

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -1,6 +1,6 @@
 import API from '../apolloClient';
 import { gql } from '@apollo/client';
-import { useQuery } from 'react-query';
+import { useQuery, useMutation, useQueryClient  } from 'react-query';
 
 const journalEntry = gql`
   query JournalEntry($id: Int) {
@@ -164,7 +164,7 @@ export const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUp
   return data.updateJournalEntry;
 }
 
-const deleteJournalEntryQuery = `
+const deleteJournalEntryQuery = gql`
   mutation deleteJournalEntry($where: JournalEntryWhereUniqueInput!) {
     deleteJournalEntry(where: $where) {
       id
@@ -172,11 +172,11 @@ const deleteJournalEntryQuery = `
   }
 `
 
-export const deleteJournalEntry = async (id: number) => {
+export const deleteJournalEntryMutation = async (id: number) => {
   const { data } = await API.mutate<any>({
-    mutation: gql(deleteJournalEntryQuery),
+    mutation: deleteJournalEntryQuery,
     variables: { where: { id: Number(id) } }
   });
 
   return data.deleteJournalEntry;
-};
+}

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -164,7 +164,7 @@ export const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUp
   return data.updateJournalEntry;
 }
 
-const deleteJournalEntryQuery = gql`
+const deleteJournalEntryMutation = gql`
   mutation deleteJournalEntry($where: JournalEntryWhereUniqueInput!) {
     deleteJournalEntry(where: $where) {
       id
@@ -172,11 +172,22 @@ const deleteJournalEntryQuery = gql`
   }
 `
 
-export const deleteJournalEntryMutation = async (id: number) => {
+const deleteJournalEntry = async (id: number) => {
   const { data } = await API.mutate<any>({
-    mutation: deleteJournalEntryQuery,
+    mutation: deleteJournalEntryMutation,
     variables: { where: { id: Number(id) } }
   });
 
   return data.deleteJournalEntry;
+}
+
+export const useDeleteJournalEntry = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation(deleteJournalEntry, {
+    onSuccess: (_, id) => {
+      queryClient.setQueryData("journalEntries", (oldData: any) => oldData.filter((entry: { id: number; }) => entry.id !== id))
+    }
+  })
+
 }

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -8,7 +8,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import WarningModal from '../WarningModal/WarningModal';
 import { useNavigate } from 'react-router-dom';
 import { JournalEntry } from '../../pages/DashboardPage/DashboardPage';
-import { deleteJournalEntry } from '../../api/journalEntries/journalEntry';
+import { deleteJournalEntryMutation } from '../../api/journalEntries/journalEntry';
+import { useMutation, useQueryClient } from 'react-query';
 import './JournalEntryCard.css';
 
 interface JournalEntryCardProps {
@@ -20,7 +21,14 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
   const { entry, triggerDeleteSnackBar } = props;
   const navigate = useNavigate();
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
-  const [error, setError] = useState(false)
+  const [error, setError] = useState(false);
+  const queryClient = useQueryClient();
+  // console.log(queryClient)
+  const deleteJournalEntryChange = useMutation(deleteJournalEntryMutation, {
+    onSuccess: (_, id) => {
+      queryClient.setQueryData("journalEntries", (oldData: any) => oldData.filter((entry: { id: number; }) => entry.id !== id))
+    }
+});
 
   const onEditClick = (callback: () => void) => {
     return () => {
@@ -30,8 +38,8 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
 
   const onDeleteClick = async () => {
     try {
-      const deleteResults = await deleteJournalEntry(entry.id);
-      triggerDeleteSnackBar(deleteResults ? true : false);
+      deleteJournalEntryChange.mutate(entry.id)
+      triggerDeleteSnackBar(true);
     } catch (err) {
       console.log(err);
       triggerDeleteSnackBar(false);

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -8,8 +8,7 @@ import EditIcon from '@mui/icons-material/Edit';
 import WarningModal from '../WarningModal/WarningModal';
 import { useNavigate } from 'react-router-dom';
 import { JournalEntry } from '../../pages/DashboardPage/DashboardPage';
-import { deleteJournalEntryMutation } from '../../api/journalEntries/journalEntry';
-import { useMutation, useQueryClient } from 'react-query';
+import { useDeleteJournalEntry } from '../../api/journalEntries/journalEntry';
 import './JournalEntryCard.css';
 
 interface JournalEntryCardProps {
@@ -21,14 +20,7 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
   const { entry, triggerDeleteSnackBar } = props;
   const navigate = useNavigate();
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
-  const [error, setError] = useState(false);
-  const queryClient = useQueryClient();
-  // console.log(queryClient)
-  const deleteJournalEntryChange = useMutation(deleteJournalEntryMutation, {
-    onSuccess: (_, id) => {
-      queryClient.setQueryData("journalEntries", (oldData: any) => oldData.filter((entry: { id: number; }) => entry.id !== id))
-    }
-});
+  const deleteJournalEntry = useDeleteJournalEntry();
 
   const onEditClick = (callback: () => void) => {
     return () => {
@@ -38,7 +30,7 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
 
   const onDeleteClick = async () => {
     try {
-      deleteJournalEntryChange.mutate(entry.id)
+      deleteJournalEntry.mutate(entry.id)
       triggerDeleteSnackBar(true);
     } catch (err) {
       console.log(err);

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -28,7 +28,7 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
     }
   }
 
-  const onDeleteClick = async () => {
+  const onDeleteClick = () => {
     try {
       deleteJournalEntry.mutate(entry.id)
       triggerDeleteSnackBar(true);

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -6,8 +6,6 @@ import moment from 'moment';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import WarningModal from '../WarningModal/WarningModal';
-import { SnackBar, SnackBarDetails } from '../SnackBar/SnackBar';
-import { Alert } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { JournalEntry } from '../../pages/DashboardPage/DashboardPage';
 import { deleteJournalEntry } from '../../api/journalEntries/journalEntry';
@@ -15,18 +13,14 @@ import './JournalEntryCard.css';
 
 interface JournalEntryCardProps {
   entry: JournalEntry;
+  triggerDeleteSnackBar: (deleteResults: boolean) => void;
 }
 
 const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
-  const { entry } = props;
+  const { entry, triggerDeleteSnackBar } = props;
   const navigate = useNavigate();
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
-  const [snackBarDetails, setSnackBarDetails] = useState<SnackBarDetails>({} as SnackBarDetails);
   const [error, setError] = useState(false)
-
-  const dismissSnackBar = () => {
-    setSnackBarDetails({ ...snackBarDetails, show: false });
-  };
 
   const onEditClick = (callback: () => void) => {
     return () => {
@@ -35,24 +29,19 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
   }
 
   const onDeleteClick = async () => {
-    let deleteResults = '';
     try {
-      deleteResults = await deleteJournalEntry(entry.id)
-    } catch (error) {
-      console.log(error)
-      setError(true)
-    }
-    setSnackBarDetails({ error, show: true, message: deleteResults })
+      const deleteResults = await deleteJournalEntry(entry.id);
+      triggerDeleteSnackBar(deleteResults ? true : false);
+    } catch (err) {
+      console.log(err);
+      triggerDeleteSnackBar(false);
+    };
+    
     setIsWarningModalOpen(false);
   }
 
   return (
     <>
-      <SnackBar open={snackBarDetails.show} onClose={dismissSnackBar}>
-        <Alert onClose={dismissSnackBar} severity={snackBarDetails.error ? "error" : "success"} variant="filled">
-          {snackBarDetails.message}
-        </Alert>
-      </SnackBar>
       <Box className="journal-entry-card"> 
         <Typography variant="h5"><b>{moment(entry.date).format("MMMM Do YYYY")}</b></Typography>
         <Typography variant="body1">You drank <b>{entry.waterIntake}oz</b> of water</Typography>

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -10,6 +10,7 @@ import { SnackBar, SnackBarDetails } from '../SnackBar/SnackBar';
 import { Alert } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { JournalEntry } from '../../pages/DashboardPage/DashboardPage';
+import { deleteJournalEntry } from '../../api/journalEntries/journalEntry';
 import './JournalEntryCard.css';
 
 interface JournalEntryCardProps {
@@ -33,9 +34,15 @@ const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
     }
   }
 
-  const onDeleteClick = () => {
-    console.log('Delete')
-    setSnackBarDetails({ error, show: true, message: "Journal entry deleted!" })
+  const onDeleteClick = async () => {
+    let deleteResults = '';
+    try {
+      deleteResults = await deleteJournalEntry(entry.id)
+    } catch (error) {
+      console.log(error)
+      setError(true)
+    }
+    setSnackBarDetails({ error, show: true, message: deleteResults })
     setIsWarningModalOpen(false);
   }
 

--- a/src/components/SnackBar/SnackBar.tsx
+++ b/src/components/SnackBar/SnackBar.tsx
@@ -8,7 +8,7 @@ export type SnackBarDetails = {
   };
 
 export const SnackBar: React.FC<SnackbarProps> = (props) => {
-    const { open = false, autoHideDuration = 6000, onClose, children, ...rest } = props;
+    const { open = false, autoHideDuration = 2000, onClose, children, ...rest } = props;
 
     return (
         <Snackbar open={open} autoHideDuration={autoHideDuration} onClose={onClose} anchorOrigin={{vertical: 'top', horizontal: 'center'}} {...rest}>

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -29,7 +29,7 @@ export interface JournalEntry {
 const DashboardPage = () => {
     const user = useContext(AuthContext);
     const navigate = useNavigate();
-    const { data, isFetching, refetch } = useJournalEntries(user.id);
+    const { data, isFetching } = useJournalEntries(user.id);
     const [snackBarDetails, setSnackBarDetails] = useState<SnackBarDetails>({} as SnackBarDetails);
 
     const triggerDeleteSnackBar = (deleteResults: boolean) => {
@@ -42,7 +42,6 @@ const DashboardPage = () => {
 
     const dismissSnackBar = () => {
         setSnackBarDetails({ ...snackBarDetails, show: false });
-
     };
 
     const handleNavigateToJournalEntryForm = (callback: () => void) => {
@@ -50,6 +49,7 @@ const DashboardPage = () => {
             callback()
         }
     }
+
     if (isFetching) {
         return (
             <p>Fetching data...</p>

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { AuthContext } from '../../shared/auth-context';
 import MessagePage from '../../components/MessagePage/MessagePage';
 import JournalEntryCard from '../../components/JournalEntryCard/JournalEntryCard';
@@ -8,6 +8,8 @@ import { useNavigate } from 'react-router-dom';
 import Button from '@mui/material/Button';
 import { PossibleRoutes } from '../../utils/constants';
 import { useJournalEntries } from '../../api/journalEntries/journalEntries';
+import { SnackBar, SnackBarDetails } from '../../components/SnackBar/SnackBar';
+import { Alert } from '@mui/material';
 
 import './DashboardPage.css';
 
@@ -27,7 +29,21 @@ export interface JournalEntry {
 const DashboardPage = () => {
     const user = useContext(AuthContext);
     const navigate = useNavigate();
-    const { data, isFetching } = useJournalEntries(user.id);
+    const { data, isFetching, refetch } = useJournalEntries(user.id);
+    const [snackBarDetails, setSnackBarDetails] = useState<SnackBarDetails>({} as SnackBarDetails);
+
+    const triggerDeleteSnackBar = (deleteResults: boolean) => {
+        setSnackBarDetails({ 
+            error: deleteResults, 
+            show: true, 
+            message: deleteResults ? 'Journal entry deletion successful!' : 'Something went wrong, please try again or contact us for help.'
+        })
+    }
+
+    const dismissSnackBar = () => {
+        setSnackBarDetails({ ...snackBarDetails, show: false });
+
+    };
 
     const handleNavigateToJournalEntryForm = (callback: () => void) => {
         return () => {
@@ -42,12 +58,17 @@ const DashboardPage = () => {
 
     return user.isLoggedIn ? (
         <div className="dashboard">
+            <SnackBar open={snackBarDetails.show} onClose={dismissSnackBar}>
+                <Alert onClose={dismissSnackBar} severity={snackBarDetails.error ? "success" : "error"} variant="filled">
+                    {snackBarDetails.message}
+                </Alert>
+            </SnackBar>
             <Typography variant="h2">Welcome back {user.displayName}!</Typography>
             {data.length ? 
             (
                 <Box className='dashboard-journal-entries-container'>
                     {data.map((entry: JournalEntry) => {
-                        return <JournalEntryCard entry={entry} key={entry.id}/>
+                        return <JournalEntryCard entry={entry} key={entry.id} triggerDeleteSnackBar={triggerDeleteSnackBar} />
                     })}
                 </Box>
             ) : (

--- a/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
@@ -28,7 +28,7 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
     const [garlandPose, setGarlandPose] = useState<number | string>('');
     const [prenatalVitamins, setPrenatalVitamins] = useState<boolean | null>(null);
     const [probiotics, setProbiotics] = useState<boolean | null>(null);
-    const createJournalEntry = useMutation(createJournalEntryMutation)
+    const createJournalEntry = useMutation(createJournalEntryMutation);
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();

--- a/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
@@ -9,8 +9,9 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Button from '@mui/material/Button';
-import { createJournalEntry } from '../../../api/journalEntries/journalEntry';
+import { createJournalEntryMutation } from '../../../api/journalEntries/journalEntry';
 import moment from 'moment';
+import { useMutation } from 'react-query';
 
 interface JournalEntryFormProps {
     userId: string | undefined;
@@ -27,8 +28,9 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
     const [garlandPose, setGarlandPose] = useState<number | string>('');
     const [prenatalVitamins, setPrenatalVitamins] = useState<boolean | null>(null);
     const [probiotics, setProbiotics] = useState<boolean | null>(null);
+    const createJournalEntry = useMutation(createJournalEntryMutation)
 
-    const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
         const journalEntry = {
             authorId: userId,
@@ -41,8 +43,9 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
             prenatalVitamins: prenatalVitamins,
             probiotics: probiotics,
         }
+
         try {
-            await createJournalEntry(journalEntry)
+            createJournalEntry.mutate(journalEntry)
             handleSubmitResults("success")
         } catch (error) {
             console.log(error)

--- a/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
@@ -9,9 +9,8 @@ import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Button from '@mui/material/Button';
-import { createJournalEntryMutation } from '../../../api/journalEntries/journalEntry';
+import { useCreateJournalEntry } from '../../../api/journalEntries/journalEntry';
 import moment from 'moment';
-import { useMutation } from 'react-query';
 
 interface JournalEntryFormProps {
     userId: string | undefined;
@@ -28,7 +27,7 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
     const [garlandPose, setGarlandPose] = useState<number | string>('');
     const [prenatalVitamins, setPrenatalVitamins] = useState<boolean | null>(null);
     const [probiotics, setProbiotics] = useState<boolean | null>(null);
-    const createJournalEntry = useMutation(createJournalEntryMutation);
+    const createJournalEntry = useCreateJournalEntry();
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();


### PR DESCRIPTION
What this PR does: 
- Creates delete journal entry query so that the user can delete a journal entry from their dashboard
- Moves the snackbar to the dashboard for when an entry is delete the user is notified of success or failure
- Makes use of useMutation and queryClient from react-query in order to delete a journal entry, then update the cached data so that the dashboard displays properly
- Makes use of useMutation and queryClient from react-query in order to create a journal entry, then refetch the user's journalEntries query by invalidating the cached data. This is used instead of updating the cached data in case the user is logged in already and there is not cached data for their dashboard
- By using useMutation, custom hooks are created and imported instead of having to import useMutation and useQueryClient in multiple locations