### PR TITLE
Journal Entry Form verification and updating dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,16 @@ import {
 import apolloClient from './api/apolloClient';
 import { ApolloProvider } from '@apollo/client';
 import { QueryClient, QueryClientProvider } from 'react-query';
+import { ReactQueryDevtools } from 'react-query/devtools';
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false
+    },
+  },
+});
 
 initializeApp(firebaseConfig);
 
@@ -71,6 +79,7 @@ const App = () => {
         >
           <ThemeProvider theme={theme}>
             <Router>
+              <ReactQueryDevtools initialIsOpen={false} />
               <AppBar />
               {routes}
               <AppFooter />

--- a/src/api/journalEntries/journalEntries.ts
+++ b/src/api/journalEntries/journalEntries.ts
@@ -2,7 +2,7 @@ import API from '../apolloClient';
 import { gql } from '@apollo/client';
 import { useQuery } from 'react-query';
 
-const journalEntries = gql`
+export const journalEntries = gql`
   query JournalEntries($authorId: String) {
     journalEntries(where: { authorId: { equals: $authorId } }) {
       id

--- a/src/api/journalEntries/journalEntries.ts
+++ b/src/api/journalEntries/journalEntries.ts
@@ -30,7 +30,7 @@ export const useJournalEntries = (authorId: string | undefined) => {
     });
 };
 
-const authorJournalEntries = gql`
+const authorJournalEntry = gql`
   query JournalEntries($id: Int, $authorId: String) {
     journalEntries(where: { AND: [{ id: { equals: $id } }, { authorId: { equals: $authorId } }]}) {
       id
@@ -48,13 +48,13 @@ const authorJournalEntries = gql`
 `;
 
 export const useAuthorJournalEntry = (id: string | undefined, authorId: string | undefined) => {
-    return useQuery(['authorJournalEntries'], async () => {
+    return useQuery(['authorJournalEntry'], async () => {
         const variables = {
             id: Number(id), 
             authorId
         };
         const { data } = await API.query<any>({
-            query: authorJournalEntries,
+            query: authorJournalEntry,
             variables
         });
 

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -176,8 +176,11 @@ export const useUpdateJournalEntry = () => {
   const queryClient = useQueryClient();
 
   return useMutation(updateJournalEntry, {
-    onSuccess: async () => {
-      await queryClient.invalidateQueries("journalEntries")
+    onSuccess: (newEntry) => {
+        queryClient.setQueryData(["journalEntries"], (oldData: any) => {
+        const unchangedEntries = oldData.filter((entry: { id: number; }) => entry.id !== newEntry.id)
+        return [...unchangedEntries, newEntry]
+      })
     }
   })
 }

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -35,6 +35,7 @@ const createJournalEntryMutation = gql`
     createJournalEntry(
       data: $data
     ) {
+      id
       date
       exercise
       garlandPose
@@ -97,9 +98,10 @@ export const useCreateJournalEntry = () => {
   const queryClient = useQueryClient();
 
   return useMutation(createJournalEntry, {
-    // can be moved to NewJournalEntryForm
-    onSuccess: async () => {
-      await queryClient.invalidateQueries("journalEntries")
+    onSuccess: (newEntry) => {
+      queryClient.setQueryData(["journalEntries"], (oldData: any) => {
+        return [...oldData, newEntry]
+      })
     }
   })
 }
@@ -205,5 +207,4 @@ export const useDeleteJournalEntry = () => {
       await queryClient.setQueryData("journalEntries", (oldData: any) => oldData.filter((entry: { id: number; }) => entry.id !== id))
     }
   })
-
 }

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -31,7 +31,7 @@ export const useJournalEntry = (id: string) => {
 };
 
 const createJournalEntryMutation = gql`
-  mutation createJournalEntry($data: JournalEntryCreateInput!){
+  mutation createJournalEntry($data: JournalEntryCreateInputData!){
     createJournalEntry(
       data: $data
     ) {
@@ -82,11 +82,7 @@ const createJournalEntry = async (createJournalEntryInput: JournalEntryCreate) =
     "probiotics": probiotics,
     "proteinIntake": proteinIntake,
     "waterIntake": waterIntake,
-    "author": {
-      "connect": {
-        "id": authorId
-      }
-    }
+    "authorId": authorId
   };
 
   const { data } = await API.mutate<any>({
@@ -101,6 +97,7 @@ export const useCreateJournalEntry = () => {
   const queryClient = useQueryClient();
 
   return useMutation(createJournalEntry, {
+    // can be moved to NewJournalEntryForm
     onSuccess: async () => {
       await queryClient.invalidateQueries("journalEntries")
     }

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -178,7 +178,7 @@ export const useUpdateJournalEntry = () => {
 
   return useMutation(updateJournalEntry, {
     onSuccess: async (newEntry) => {
-      await queryClient.fetchQuery(["journalEntries"], async () => {
+      const previousEntries = await queryClient.fetchQuery(["journalEntries"], async () => {
         const { data } = await API.query<any>({
             query: journalEntries,
             variables: { authorId: newEntry.authorId }
@@ -186,12 +186,7 @@ export const useUpdateJournalEntry = () => {
 
         return data.journalEntries;
       })
-      queryClient.setQueryData(["journalEntries"], (oldData: any) => {
-        if (oldData.length) {
-          const unchangedEntries = oldData.filter((entry: { id: number; }) => entry.id !== newEntry.id)
-          return [...unchangedEntries, newEntry]
-        }
-      })
+      return previousEntries
     }
   })
 }

--- a/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
+++ b/src/pages/JournalEntryFormPage/JournalEntryFormPage.tsx
@@ -17,11 +17,11 @@ const JournalEntryFormPage: React.FC = () => {
         setSnackBarDetails({ ...snackBarDetails, show: false });
     };
 
-    const handleSubmitResults = (results: string) => {
-        if (results === "success") {
+    const handleSubmitResults = (error: boolean, message?: string) => {
+        if (!error) {
             setSnackBarDetails({ error: false, show: true, message: `Journal entry ${entryId ? 'updated' : 'created'}!` })
-        } else if (results === "error") {
-            setSnackBarDetails({ error: true, show: true, message: `Something went wrong, please try again` })
+        } else if (error) {
+            setSnackBarDetails({ error: true, show: true, message: message || `Something went wrong, please try again` })
         }
     }
 

--- a/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
@@ -43,13 +43,13 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
             probiotics: probiotics,
         }
 
-        try {
-            createJournalEntry.mutate(journalEntry)
-            handleSubmitResults("success")
-        } catch (error) {
-            console.log(error)
-            handleSubmitResults("error")
-        }
+        createJournalEntry.mutate(journalEntry, {
+            // Working here, can do things with the results!
+            onError: (err) => {
+                console.log(err)
+            }
+        })
+        handleSubmitResults("success")
     }
 
     return (
@@ -64,7 +64,7 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
             <LocalizationProvider dateAdapter={DateAdapter}>
                 <DatePicker
                     value={date}
-                    onChange={(newDate) => setDate(moment(newDate).toISOString())}
+                    onChange={(newDate) => setDate(moment(newDate).startOf('day').toISOString(true))}
                     renderInput={(params) => <TextField required size='small' sx={{width: "200px"}} {...params} />}
                 />
             </LocalizationProvider>

--- a/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/NewJournalEntryForm/NewJournalEntryForm.tsx
@@ -14,7 +14,7 @@ import moment from 'moment';
 
 interface JournalEntryFormProps {
     userId: string | undefined;
-    handleSubmitResults: (results: string) => void;
+    handleSubmitResults: (error: boolean, message?: string) => void;
 }
 
 const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
@@ -31,6 +31,7 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
+
         const journalEntry = {
             authorId: userId,
             date: date,
@@ -41,16 +42,17 @@ const JournalEntryForm: React.FC<JournalEntryFormProps> = (props) => {
             garlandPose: garlandPose,
             prenatalVitamins: prenatalVitamins,
             probiotics: probiotics,
-        }
-
+        };
+    
         createJournalEntry.mutate(journalEntry, {
-            // Working here, can do things with the results!
-            onError: (err) => {
-                console.log(err)
+            onError: (err: any) => {
+                handleSubmitResults(true, err.message)
+            },
+            onSuccess: () => {
+                handleSubmitResults(false)
             }
-        })
-        handleSubmitResults("success")
-    }
+        });
+    };
 
     return (
         <form className="form" onSubmit={handleSubmit}>

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -20,7 +20,7 @@ import moment from 'moment';
 
 interface UpdateJournalEntryFormProps {
     entryId: string;
-    handleSubmitResults: (results: string) => void;
+    handleSubmitResults: (error: boolean, message?: string) => void;
     userId: string | undefined;
 }
 
@@ -56,13 +56,13 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
         if (JSON.stringify(updatedJournalEntry) !== JSON.stringify(previousEntry)) {
             try {
                 updateJournalEntry.mutate(updatedJournalEntry);
-                handleSubmitResults("success");
+                handleSubmitResults(false);
             } catch (error) {
                 console.log(error);
-                handleSubmitResults("error");
+                handleSubmitResults(true);
             };
         } else {
-            handleSubmitResults("error");
+            handleSubmitResults(true);
         };
     };
 

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -103,7 +103,9 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
     }, [data, entryId]);
 
     useEffect(() => {
-        queryClient.removeQueries(["authorJournalEntry"])
+        if (queryClient.getQueryData(["authorJournalEntry"])) {
+            queryClient.removeQueries(["authorJournalEntry"])
+        }
     }, []) // eslint-disable-line 
     // the above disable is to remove warning of needing queryClient as a dependency but we only want the useEffect to run once
 

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -16,6 +16,7 @@ import MessagePage from '../../../components/MessagePage/MessagePage';
 import { useAuthorJournalEntry } from '../../../api/journalEntries/journalEntries';
 import { useUpdateJournalEntry } from '../../../api/journalEntries/journalEntry';
 import moment from 'moment';
+import { useQueryClient } from 'react-query';
 
 
 interface UpdateJournalEntryFormProps {
@@ -38,6 +39,7 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
     const [probiotics, setProbiotics] = useState<boolean | null>(null);
     const [previousEntry, setPreviousEntry] = useState<{}>({})
     const updateJournalEntry = useUpdateJournalEntry();
+    const queryClient = useQueryClient();
 
     const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -98,6 +100,11 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
         } 
     }, [data, entryId]);
 
+    useEffect(() => {
+        queryClient.removeQueries(["authorJournalEntry"])
+    }, []) // eslint-disable-line 
+    // the above disable is to remove warning of needing queryClient as a dependency but we only want the useEffect to run once
+    
     if (isFetching) {
         return (
             <p>Fetching data...</p>

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -116,7 +116,7 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
             <LocalizationProvider dateAdapter={DateAdapter}>
                 <DatePicker
                     value={date}
-                    onChange={(newDate) => setDate(moment(newDate).toISOString())}
+                    onChange={(newDate) => setDate(moment(newDate).startOf('day').toISOString(true))}
                     renderInput={(params) => <TextField required size='small' sx={{width: "200px"}} {...params} />}
                 />
             </LocalizationProvider>

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -56,13 +56,15 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
         };
 
         if (JSON.stringify(updatedJournalEntry) !== JSON.stringify(previousEntry)) {
-            try {
-                updateJournalEntry.mutate(updatedJournalEntry);
-                handleSubmitResults(false);
-            } catch (error) {
-                console.log(error);
-                handleSubmitResults(true);
-            };
+            updateJournalEntry.mutate(updatedJournalEntry, {
+                onError: (err: any) => {
+                    handleSubmitResults(true, err.message)
+                },
+                onSuccess: () => {
+                    handleSubmitResults(false)
+                }
+            });
+            handleSubmitResults(false);
         } else {
             handleSubmitResults(true);
         };
@@ -104,7 +106,7 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
         queryClient.removeQueries(["authorJournalEntry"])
     }, []) // eslint-disable-line 
     // the above disable is to remove warning of needing queryClient as a dependency but we only want the useEffect to run once
-    
+
     if (isFetching) {
         return (
             <p>Fetching data...</p>


### PR DESCRIPTION
What this PR does:
- Verifies that the user has made a change to the updateJournalEntryForm once submitted, notifies if no change has been made but if it has then the mutation is tried
- handleSubmitResults on journal entry forms is fixed to take an error boolean and possible message
- Adds ReactQueryDevTools
- Change date on journal entries to be saved as start of day for comparison done on backend to make sure only one date can be used
- Changes mutation so that when creating a journal entry the user will see the new entry on the dashboard onSuccess