### PR TITLE
Update mutation to include custom updateJournalEntry resolver

### DIFF
--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -117,15 +117,16 @@ interface JournalEntryUpdate {
   garlandPose: number | string;
   prenatalVitamins: boolean | null;
   probiotics: boolean | null;
+  authorId: string | undefined;
 }
 
 const updateJournalEntryMutation = gql`
   mutation updateJournalEntry(
-    $data: JournalEntryUpdateInput!
-    $where: JournalEntryWhereUniqueInput!
+    $data: JournalEntryCreateInputData!
+    $updateJournalEntryId: Int!
   ) { updateJournalEntry(
     data: $data
-    where: $where
+    id: $updateJournalEntryId
   ) {
     id
     date
@@ -152,22 +153,24 @@ const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUpdate) =
     probiotics, 
     proteinIntake, 
     waterIntake, 
+    authorId
   } = updateJournalEntryInput;
 
   const variables = {
-    "date": { "set": date },
-    "exercise": { "set": exercise },
-    "garlandPose": { "set": garlandPose },
-    "kegels": { "set": kegels },
-    "prenatalVitamins": { "set": prenatalVitamins },
-    "probiotics": { "set": probiotics },
-    "proteinIntake": { "set": proteinIntake },
-    "waterIntake": { "set": waterIntake }
+    "date": date,
+    "exercise": exercise,
+    "garlandPose": garlandPose,
+    "kegels": kegels,
+    "prenatalVitamins": prenatalVitamins,
+    "probiotics": probiotics,
+    "proteinIntake": proteinIntake,
+    "waterIntake": waterIntake,
+    "authorId": authorId 
   };
 
   const { data } = await API.mutate<any>({
     mutation: updateJournalEntryMutation,
-    variables: { data: variables, where: { id: Number(id) }}
+    variables: { data: variables, updateJournalEntryId: Number(id) }
   });
 
   return data.updateJournalEntry;

--- a/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
+++ b/src/pages/JournalEntryFormPage/UpdateJournalEntryForm/UpdateJournalEntryForm.tsx
@@ -53,6 +53,7 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
             garlandPose: garlandPose,
             prenatalVitamins: prenatalVitamins,
             probiotics: probiotics,
+            authorId: userId
         };
 
         if (JSON.stringify(updatedJournalEntry) !== JSON.stringify(previousEntry)) {
@@ -97,10 +98,11 @@ const UpdateJournalEntryForm: React.FC<UpdateJournalEntryFormProps> = (props) =>
                     garlandPose: data[0].garlandPose,
                     prenatalVitamins: data[0].prenatalVitamins,
                     probiotics: data[0].probiotics,
+                    authorId: userId
                 }
             )
         } 
-    }, [data, entryId]);
+    }, [data, entryId, userId]);
 
     useEffect(() => {
         if (queryClient.getQueryData(["authorJournalEntry"])) {


### PR DESCRIPTION
What this PR does: 
- Once the custom resolver for updating a journal entry was created, needed to update the call on the frontend to match the changes.
- Includes the authorId in the params
- Changes the args for the mutation call, dependent on the definition on the backend