### PR TITLE
Order journal entries by date in desc order, aka closest to today first

### DIFF
--- a/src/api/journalEntries/journalEntries.ts
+++ b/src/api/journalEntries/journalEntries.ts
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query';
 
 export const journalEntries = gql`
   query JournalEntries($authorId: String) {
-    journalEntries(where: { authorId: { equals: $authorId } }) {
+    journalEntries(orderBy: [ { date: desc } ], where: { authorId: { equals: $authorId } }) {
       id
       date
       exercise


### PR DESCRIPTION
What this PR does: 
- When the query is made, it orders then according to the entry's date. The journal entries are then displayed in a descending order so that the most recent entries are first.