### PR TITLE
Add setDisplayNameOnCreate to user context to set display name when creating an account with email and password

### DIFF
--- a/src/App.authProvider.tsx
+++ b/src/App.authProvider.tsx
@@ -19,17 +19,23 @@ const AuthProvider: React.FC<AuthProviderProps> = (props) => {
     const [displayName, setDisplayName] = useState<string | null>('');
     const [photoURL, setPhotoURL] = useState<string | null>('');
     const [expectedDueDate, setExpectedDueDate] = useState<string | null>(null);
-    const { data } = useUser(userId, displayName);
+    const [email, setEmail] = useState<string | null>('');
+    const { data } = useUser(userId, email);
 
     const updateExpectedDueDate = (newDueDate: string) => {
         setExpectedDueDate(newDueDate)
+    }
+    
+    const setDisplayNameOnCreate = (displayName: string) => {
+        setDisplayName(displayName)
     }
 
     onAuthStateChanged(auth, (user) => {
         if (user) {
             setUserId(user.uid);
+            setEmail(user.email);
             setIsLoggedIn(true);
-            setDisplayName(user.displayName);
+            
             setPhotoURL(user.photoURL);
         } else {
             setUserId(undefined);
@@ -43,6 +49,7 @@ const AuthProvider: React.FC<AuthProviderProps> = (props) => {
 
     React.useEffect(() => {
         if (data && data.id === userId) {
+            setDisplayName(data.displayName);
             setExpectedDueDate(data.expectedDueDate);
         } 
     }, [data, userId]);
@@ -55,7 +62,8 @@ const AuthProvider: React.FC<AuthProviderProps> = (props) => {
             displayName: displayName,
             photoURL: photoURL,
             expectedDueDate: expectedDueDate,
-            setExpectedDueDate: updateExpectedDueDate
+            setExpectedDueDate: updateExpectedDueDate,
+            setDisplayNameOnCreate: setDisplayNameOnCreate
             }}
         >
             {props.children}

--- a/src/features/LoginModal/CreateAccountForm/CreateAccountForm.tsx
+++ b/src/features/LoginModal/CreateAccountForm/CreateAccountForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
@@ -9,6 +9,7 @@ import LoadingButton from '@mui/lab/LoadingButton';
 import { useNavigate } from 'react-router-dom';
 import Divider from '@mui/material/Divider';
 import ProviderLoginButton from '../../../components/ProviderLoginButton/ProviderLoginButton';
+import { AuthContext } from '../../../shared/auth-context';
 
 import './CreateAccountForm.css';
 
@@ -28,6 +29,7 @@ const CreateAccountForm: React.FC<CreateAccountFormProps> = (props) => {
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const loginUser = useLoginUser();
     const navigate = useNavigate();
+    const user = useContext(AuthContext);
 
     const createAccount = async (email: string, password: string, firstName: string, lastName: string) => {
         setIsLoading(true)
@@ -41,6 +43,7 @@ const CreateAccountForm: React.FC<CreateAccountFormProps> = (props) => {
                     console.log(err)
                 },
                 onSuccess: () => {
+                    user.setDisplayNameOnCreate(displayName)
                     setIsLoading(false)
                     onClose()
                     navigate('/dashboard/home')

--- a/src/features/UserAside/UserAside.css
+++ b/src/features/UserAside/UserAside.css
@@ -5,4 +5,5 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    text-align: center;
 }

--- a/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
+++ b/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
@@ -39,7 +39,7 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
         e.preventDefault();
         setIsLoading(true)
 
-        if (JSON.stringify(user.expectedDueDate) !== JSON.stringify(date)) {
+        if (JSON.stringify(user.expectedDueDate) !== JSON.stringify(date) && date !== null) {
             const updateUserInput = {
                 id: user.id,
                 expectedDueDate: date
@@ -50,7 +50,7 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
                 },
                 onSuccess: async () => {
                     triggerSnackBar(false, 'Profile update successful!');
-                    await user.setExpectedDueDate(date)
+                    user.setExpectedDueDate(date)
                     setIsEditing(false)
                 },
                 onSettled: () => {

--- a/src/shared/auth-context.ts
+++ b/src/shared/auth-context.ts
@@ -6,7 +6,8 @@ export interface User {
     displayName: string | null;
     photoURL: string | null;
     expectedDueDate: string | null;
-    setExpectedDueDate: any;
+    setExpectedDueDate: (newDueDate: string) => void;
+    setDisplayNameOnCreate: (displayName: string) => void;
 }
 
 export const AuthContext = createContext<User>({ 
@@ -15,5 +16,6 @@ export const AuthContext = createContext<User>({
     displayName: '',
     photoURL: '',
     expectedDueDate: null,
-    setExpectedDueDate: () => {}
+    setExpectedDueDate: () => {},
+    setDisplayNameOnCreate: () => {}
 })


### PR DESCRIPTION
What this PR does: 
- Adds setDisplayNameOnCreate to userContext so once a user creates an account their display name is set and will be visible on their dashboard in the UserAside and on the AppBar menu