### PR TITLE
Disable guest profile deletion

### DIFF
--- a/src/App.authProvider.tsx
+++ b/src/App.authProvider.tsx
@@ -64,6 +64,7 @@ const AuthProvider: React.FC<AuthProviderProps> = (props) => {
             displayName: displayName,
             photoURL: photoURL,
             expectedDueDate: expectedDueDate,
+            email: email,
             setExpectedDueDate: updateExpectedDueDate,
             setDisplayNameOnCreate: setDisplayNameOnCreate
             }}

--- a/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
+++ b/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
@@ -131,6 +131,10 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
         }
     }
 
+    const onDeleteGuestProfile = () => {
+        triggerSnackBar(true, 'You can not delete the guest account!');
+    }
+
     useEffect(() => {
         if (user.expectedDueDate) {
             setDate(user.expectedDueDate)
@@ -183,7 +187,7 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
                             <Box className="profile-delete-button">
                                 <Button 
                                     variant="contained" 
-                                    onClick={() => setIsDeletingAccount(true)}
+                                    onClick={user.email === 'guest@guest.com' ? () => onDeleteGuestProfile() : () => setIsDeletingAccount(true)}
                                     startIcon={<DeleteIcon />}
                                     color="warning"
                                     size="small"

--- a/src/shared/auth-context.ts
+++ b/src/shared/auth-context.ts
@@ -6,6 +6,7 @@ export interface User {
     displayName: string | null;
     photoURL: string | null;
     expectedDueDate: string | null;
+    email: string | null;
     setExpectedDueDate: (newDueDate: string) => void;
     setDisplayNameOnCreate: (displayName: string) => void;
 }
@@ -16,6 +17,7 @@ export const AuthContext = createContext<User>({
     displayName: '',
     photoURL: '',
     expectedDueDate: null,
+    email: '',
     setExpectedDueDate: () => {},
     setDisplayNameOnCreate: () => {}
 })


### PR DESCRIPTION
What this PR does:
- Adds email back to user context
- Adds conditional on user profile so that if it is the "guest@guest.com" account, on delete account click a warning modal pops up stating "" You can not delete the guest account"