### PR TITLE
Feature setting auth token on log in

### DIFF
--- a/cypress/integration/landing_page_spec.ts
+++ b/cypress/integration/landing_page_spec.ts
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+// Move header and footer to a shared folder, own files each
 import { hasOperationName, aliasQuery, aliasMutation } from '../utils/graphql-test-utils'
 
 describe('Landing Page', () => {
@@ -154,6 +155,15 @@ describe('AppBar', () => {
     cy.url().should('equal', 'http://localhost:3000/')
   })
 
+  // Test for Registering navigation, don't need to click. only exist on registration spec
+  // Test for require email and require password
+  // Test for requires valid username and password
+  // Redirects to dashboard on success
+  // Error handling
+  // [data-test=email] [data-test=password]
+  // cy.hash().should('eq', '#/')
+  // cy.login() -> create special function to login, under support folder -> command
+  // cy.request({})
   it('Should have a login button which opens a login modal containing a login form which logs in a user with email and password.', () => {
     cy.get('header .login-button button').contains('Log In').click()
     cy.get('.login-modal').should('be.visible')
@@ -222,6 +232,7 @@ describe('AppBar', () => {
     cy.url().should('equal', 'http://localhost:3000/dashboard')
   })
 
+  // check url is landing page
   it('Should change back to LOG IN once a user logs out.', () => {
     cy.get('header .login-button button').click()
     cy.get('.login-form #Email').eq(0).type('guest@guest.com')

--- a/src/api/journalEntries/journalEntries.ts
+++ b/src/api/journalEntries/journalEntries.ts
@@ -1,6 +1,7 @@
 import { useQuery } from 'react-query';
 import { request, gql } from "graphql-request";
 import { endpoint } from '../../App';
+import { getAuthToken } from '../../App.authProvider';
 
 export const JournalEntries = gql`
   query JournalEntries(
@@ -35,11 +36,16 @@ export const useJournalEntries = (
   count: number | undefined
 ) => {
   return useQuery(['journalEntries', count, skip], async () => {
+    const token = getAuthToken();
+    const requestHeaders = {
+      authorization: `Bearer ${token}`
+    }
     const { journalEntries } = await request(
       {
         url: endpoint,
         document: JournalEntries,
-        variables: { authorId, limit, skip }
+        variables: { authorId, limit, skip },
+        requestHeaders
       });
       return journalEntries;
     }, {
@@ -93,11 +99,16 @@ const journalEntriesCount = gql`
 `;
 
 export const useJournalEntriesCount = (authorId: string | undefined) => {
+  const token = getAuthToken();
+  const requestHeaders = {
+    authorization: `Bearer ${token}`
+  }
   return useQuery(['journalEntriesCount'], async () => {
     const { aggregateJournalEntry } = await request({
       url: endpoint,
       document: journalEntriesCount,
-      variables: { authorId }
+      variables: { authorId },
+      requestHeaders
     });
     return aggregateJournalEntry._count._all;
   }, {

--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient  } from 'react-query';
 import { request, gql } from "graphql-request";
 import { endpoint } from '../../App';
+import { getAuthToken } from '../../App.authProvider';
 
 // Needs to be modified for graphql-request
 // const journalEntry = gql`
@@ -63,6 +64,11 @@ interface JournalEntryCreateInput {
 }
 
 const createJournalEntry = async (createJournalEntryInput: JournalEntryCreateInput) => {
+  const token = getAuthToken();
+  const requestHeaders = {
+    authorization: `Bearer ${token}`
+  }
+
   const { 
     date, 
     exercise, 
@@ -90,7 +96,8 @@ const createJournalEntry = async (createJournalEntryInput: JournalEntryCreateInp
   const { createJournalEntry } = await request({
     url: endpoint,
     document: createJournalEntryMutation,
-    variables: { data: variables}
+    variables: { data: variables},
+    requestHeaders
   });
   return createJournalEntry;
 }
@@ -142,6 +149,10 @@ const updateJournalEntryMutation = gql`
 `;
 
 const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUpdateInput) => {
+  const token = getAuthToken();
+  const requestHeaders = {
+    authorization: `Bearer ${token}`
+  }
   const { 
     id,
     date, 
@@ -170,7 +181,8 @@ const updateJournalEntry = async (updateJournalEntryInput: JournalEntryUpdateInp
   const { updateJournalEntry } = await request({
     url: endpoint,
     document: updateJournalEntryMutation,
-    variables: { data: variables, updateJournalEntryId: Number(id) }
+    variables: { data: variables, updateJournalEntryId: Number(id) },
+    requestHeaders
   });
   return updateJournalEntry;
 }
@@ -195,10 +207,16 @@ const deleteJournalEntryMutation = gql`
 `
 
 const deleteJournalEntry = async (id: number) => {
+  const token = getAuthToken();
+  const requestHeaders = {
+    authorization: `Bearer ${token}`
+  }
+
   const { deleteJournalEntry } = await request({
     url: endpoint,
     document: deleteJournalEntryMutation,
-    variables: { where: { id: Number(id) } }
+    variables: { where: { id: Number(id) } },
+    requestHeaders
   });
 
   return deleteJournalEntry;

--- a/src/api/users/user.ts
+++ b/src/api/users/user.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation } from 'react-query';
 import { request, gql } from "graphql-request";
 import { endpoint } from '../../App';
+import { getAuthToken } from '../../App.authProvider';
 
 const userDocument = gql`
     query User($id: String) {
@@ -13,16 +14,21 @@ const userDocument = gql`
     }
 `;
 
-export const useUser = (id: string | undefined, displayName: string | null) => {
-    return useQuery(['user', displayName], async () => {
+export const useUser = (id: string | undefined, email: string | null) => {
+    const token = getAuthToken();
+    const requestHeaders = {
+        authorization: `Bearer ${token}`
+    }
+    return useQuery(['user', email], async () => {
         const { user } = await request({
             url: endpoint,
             document: userDocument,
-            variables: { id }
+            variables: { id },
+            requestHeaders
         });
         return user;
     }, {
-        enabled: id !== undefined && id !== null && id !== ''
+        enabled: id !== undefined && id !== null && id !== '' && email !== ''
     })
 }
 
@@ -46,6 +52,10 @@ interface UserLoginInput {
 };
 
 const loginUserMutation = async (createUserInput: UserLoginInput) => {
+    const token = getAuthToken();
+    const requestHeaders = {
+        authorization: `Bearer ${token}`
+    }
     const { id, email, displayName } = createUserInput;
 
     const variables = {
@@ -57,7 +67,8 @@ const loginUserMutation = async (createUserInput: UserLoginInput) => {
     const { loginUser } = await request({
         url: endpoint,
         document: loginUserDocument,
-        variables: { data: variables }
+        variables: { data: variables },
+        requestHeaders
     });
     return loginUser;
 };
@@ -86,6 +97,10 @@ interface UserUpdateInput {
 }
 
 const updateUserMutation = async (userUpdateInput: UserUpdateInput) => {
+    const token = getAuthToken();
+    const requestHeaders = {
+        authorization: `Bearer ${token}`
+    }
     const { id, expectedDueDate } = userUpdateInput;
 
     const variables = {
@@ -95,7 +110,8 @@ const updateUserMutation = async (userUpdateInput: UserUpdateInput) => {
     const { updateUser } = await request({
         url: endpoint,
         document: updateUserDocument,
-        variables: { data: variables, where: { "id": id } }
+        variables: { data: variables, where: { "id": id } },
+        requestHeaders
     });
 
     return updateUser;
@@ -115,10 +131,16 @@ const deleteUserDocument = gql`
 `
 
 const deleteUserMutation = async (id: string | undefined) => {
+    const token = getAuthToken();
+    const requestHeaders = {
+        authorization: `Bearer ${token}`
+    }
+
     const { deleteUser } = await request({
         url: endpoint,
         document: deleteUserDocument,
-        variables: { id }
+        variables: { id },
+        requestHeaders
     });
     
     return deleteUser;

--- a/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
+++ b/src/pages/DashboardPage/DashboardProfilePage/DashboardProfilePage.tsx
@@ -78,6 +78,13 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
         setIsLoading(true)
         if (auth.currentUser?.email) {
             try {
+                deleteUserAccount.mutate(user.id, {
+                    onError: (err: any) => {
+                        triggerSnackBar(true, err.response.errors[0].message || 'Something went wrong, please try again or contact us for help.');
+                        setIsLoading(false)
+                    },
+                })
+
                 const credential = EmailAuthProvider.credential(
                     auth.currentUser.email, 
                     password
@@ -90,12 +97,6 @@ const DashboardProfilePage: React.FC<DashboardProfilePageProps> = (props) => {
 
                 await deleteUser(result.user)
                 
-                deleteUserAccount.mutate(user.id, {
-                    onError: (err: any) => {
-                        triggerSnackBar(true, err.response.errors[0].message || 'Something went wrong, please try again or contact us for help.');
-                        setIsLoading(false)
-                    },
-                })
             } catch (err: any) {
                 triggerSnackBar(true, err.message || 'Something went wrong, please try again or contact us for help.');
                 setIsLoading(false)


### PR DESCRIPTION
What this PR does: 
- Sets the user's authentication token in localStorage on auth state change
- Retrieves the token from localStorage for queries and sets it to the Authorization header
- Moves deleteUser mutation above delete user from firebase so that the authorization header is still set