### PR TITLE
Add simple card skeletal loading placeholder

### DIFF
--- a/src/components/JournalEntryCardSkeleton/JournalEntryCardSkeleton.tsx
+++ b/src/components/JournalEntryCardSkeleton/JournalEntryCardSkeleton.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Skeleton from '@mui/material/Skeleton';
+import Box from '@mui/material/Box';
+
+
+const JournalEntryCardSkeleton = () => {
+    return (
+        <Skeleton sx={{ borderRadius: '10px', margin: '10px' }} variant='rectangular' width={300} height={263}/>
+    )
+};
+
+const JournalEntryCardSkeletonGrid = () => {
+    return (
+        <Box className='dashboard'>
+            {Array(9).fill(<JournalEntryCardSkeleton />)}
+        </Box>
+    )
+}
+
+export default JournalEntryCardSkeletonGrid;

--- a/src/features/DashboardPanel/DashboardPanel.tsx
+++ b/src/features/DashboardPanel/DashboardPanel.tsx
@@ -7,6 +7,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import Profile from '../../pages/DashboardPage/DashboardProfilePage/DashboardProfilePage';
 import NewJournalEntryForm from '../../pages/DashboardPage/DashboardNewJournalEntryFormPage/DashboardNewJournalEntryFormPage';
 import { User } from '../../shared/auth-context';
+import JournalEntryCardSkeleton from '../../components/JournalEntryCardSkeleton/JournalEntryCardSkeleton';
 
 import './DashboardPanel.css';
 
@@ -173,7 +174,7 @@ const DashboardPanel: React.FC<DashboardPanelProps> = (props) => {
         navigate(`/dashboard/${panelRoutes[0]}`)
     }
     }, [tab, panelRoutes, navigate])
-    
+
     return (
         <Box className='dashboard-panel'>
             <Box>
@@ -196,10 +197,9 @@ const DashboardPanel: React.FC<DashboardPanelProps> = (props) => {
                     />
                 </Box>
             ) : (
-                <p>Fetching...</p>
+                <JournalEntryCardSkeleton />
             )}
         </Box>
-        
     )
 }
 


### PR DESCRIPTION
What this PR does: 
- Creates a simple card placeholder using Material-ui's skeletal loading 