### PR TITLE
Switch from Array().fill() to Array().from()

### DIFF
--- a/src/components/JournalEntryCardSkeleton/JournalEntryCardSkeleton.tsx
+++ b/src/components/JournalEntryCardSkeleton/JournalEntryCardSkeleton.tsx
@@ -12,7 +12,7 @@ const JournalEntryCardSkeleton = () => {
 const JournalEntryCardSkeletonGrid = () => {
     return (
         <Box className='dashboard-journal-entries-container'>
-            {Array(9).fill(<JournalEntryCardSkeleton />)}
+            {Array.from({length:9}, (_,i) => <JournalEntryCardSkeleton key={i} />)}
         </Box>
     )
 }


### PR DESCRIPTION
What this PR does:
- Gets rid of the React warning of not having a key when displaying an array of JSX elements