### PR TITLE
Move JournalEntryCardSkeletonGrid to DashboardHomePage

### DIFF
--- a/src/features/DashboardPanel/DashboardPanel.tsx
+++ b/src/features/DashboardPanel/DashboardPanel.tsx
@@ -7,7 +7,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import Profile from '../../pages/DashboardPage/DashboardProfilePage/DashboardProfilePage';
 import NewJournalEntryForm from '../../pages/DashboardPage/DashboardNewJournalEntryFormPage/DashboardNewJournalEntryFormPage';
 import { User } from '../../shared/auth-context';
-import JournalEntryCardSkeleton from '../../components/JournalEntryCardSkeleton/JournalEntryCardSkeleton';
+// import JournalEntryCardSkeleton from '../../components/JournalEntryCardSkeleton/JournalEntryCardSkeleton';
 
 import './DashboardPanel.css';
 
@@ -181,7 +181,7 @@ const DashboardPanel: React.FC<DashboardPanelProps> = (props) => {
             <Box>
                 <DashboardTabs selectedTab={tab ? tab : dashboardPageMap[0].tab} />
             </Box>
-            {!isFetching ? (
+            {/* {!isFetching ? ( */}
                 <Box className='dashboard'>
                     <DashboardPanelViews 
                         selectedPanel={tab ? tab : dashboardPageMap[0].tab} 
@@ -197,9 +197,9 @@ const DashboardPanel: React.FC<DashboardPanelProps> = (props) => {
                         user={user}
                     />
                 </Box>
-            ) : (
+            {/* ) : (
                 <JournalEntryCardSkeleton />
-            )}
+            )} */}
         </Box>
     )
 }

--- a/src/pages/DashboardPage/DashboardHomePage/DashboardHomePage.tsx
+++ b/src/pages/DashboardPage/DashboardHomePage/DashboardHomePage.tsx
@@ -5,6 +5,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import { JournalEntry } from '../DashboardPage';
 import { useNavigate } from 'react-router-dom';
+import JournalEntryCardSkeletonGrid from '../../../components/JournalEntryCardSkeleton/JournalEntryCardSkeleton'
 
 import './DashboardHomePage.css'
 
@@ -52,6 +53,12 @@ const DashboardHomePage: React.FC<DashboardHomePageProps> = (props) => {
             }
         });
     };
+
+    if (isFetching) {
+        return (
+            <JournalEntryCardSkeletonGrid/>
+        )
+    }
 
     return (
         <>


### PR DESCRIPTION
What this PR does: 
- Moves the JournalEntryCardSkeletonGrid to DashboardHomePage instead of the dashboard panel