### PR TITLE
Feature delete entry again

### DIFF
--- a/src/api/journalEntries/journalEntry.ts
+++ b/src/api/journalEntries/journalEntry.ts
@@ -347,8 +347,10 @@ export const useDeleteJournalEntry = () => {
 
   return useMutation(deleteJournalEntry, {
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: ["journalEntriesCount"], refetchActive: false })
-      await queryClient.invalidateQueries({ queryKey: ["journalEntries"], refetchActive: false })
+      await queryClient.invalidateQueries({ queryKey: ["journalEntriesCount"], refetchInactive: true })
+      await queryClient.invalidateQueries({ queryKey: ["journalEntries"] })
+      await queryClient.invalidateQueries({ queryKey: ["firstEntry"] })
+      // await queryClient.invalidateQueries({ queryKey: ["firstEntryById"] })
     }
   })
 }

--- a/src/components/JournalEntryCard/JournalEntryCard.tsx
+++ b/src/components/JournalEntryCard/JournalEntryCard.tsx
@@ -9,14 +9,20 @@ import { useNavigate } from 'react-router-dom';
 
 interface JournalEntryCardProps {
   entry: JournalEntry;
+  email: string | null;
 };
 
 const JournalEntryCard: React.FC<JournalEntryCardProps> = (props) => {
-  const { entry } = props;
+  const { entry, email } = props;
   const navigate = useNavigate();
 
   const navigateToEntry = () => {
-    navigate(`/journal/entries/${entry.id}`)
+    if (entry.date === moment().startOf('day').toISOString(true)) {
+      navigate(`/home/${email?.split('@')[0]}`)
+    } else {
+      navigate(`/journal/entries/${entry.id}`)
+    }
+    
   }
 
   return (

--- a/src/features/JournalEntryDisplay/JournalEntryDisplay.tsx
+++ b/src/features/JournalEntryDisplay/JournalEntryDisplay.tsx
@@ -102,10 +102,10 @@ const JournalEntryDisplay: React.FC<JournalEntryDisplayProps> = (props) => {
                 onSuccess: () => {
                     triggerSnackBar(false, 'Journal entry deletion successful!');
                     if (date === moment().startOf('day').toISOString(true)) {
-                        window.scrollTo(0, 0);
+                        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
                     } else {
                         setTimeout(() => {
-                            window.scrollTo(0, 0);
+                            window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
                             navigate(`/journal/entries`);
                         }, 1500);
                     }

--- a/src/features/JournalEntryDisplay/JournalEntryDisplay.tsx
+++ b/src/features/JournalEntryDisplay/JournalEntryDisplay.tsx
@@ -24,6 +24,10 @@ import {
     EditButtonContainer
 } from "./JournalEntryDisplay.styled";
 import UpdateEntryModal from '../../components/UpdateEntryModal/UpdateEntryModal';
+import LoadingButton from '@mui/lab/LoadingButton';
+import { useDeleteJournalEntry } from '../../api/journalEntries/journalEntry';
+import { useNavigate } from 'react-router-dom';
+import moment from 'moment';
 
 interface JournalEntryDisplayProps {
     journalEntry: JournalEntry | null;
@@ -36,6 +40,9 @@ const JournalEntryDisplay: React.FC<JournalEntryDisplayProps> = (props) => {
     const { journalEntry, user, refetch, triggerSnackBar } = props;
     const [isUpdateEntryModalOpen, setIsUpdateEntryModalOpen] = useState(false);
     const [sectionEditing, setSectionEditing] = useState<string>("");
+    const [isDeleting, setIsDeleting] = useState<boolean>(false);
+    const deleteJournalEntry = useDeleteJournalEntry();
+    const navigate = useNavigate();
 
     const { 
         // id: goalsId,
@@ -47,9 +54,9 @@ const JournalEntryDisplay: React.FC<JournalEntryDisplayProps> = (props) => {
     } = user.goals;
 
     const {
-        // id,
+        id,
         // authorId,
-        // date,
+        date,
         waterIntake = 0, 
         proteinIntake = 0, 
         exercise = 0, 
@@ -82,6 +89,31 @@ const JournalEntryDisplay: React.FC<JournalEntryDisplayProps> = (props) => {
           setIsUpdateEntryModalOpen(false);
           refetch();
         };
+    };
+
+    const onDeleteClick = () => {
+        if (id) {
+            setIsDeleting(true);
+            deleteJournalEntry.mutate(id, {
+                onError: (err: any) => {
+                    triggerSnackBar(true, err.response.errors[0].message || 'Something went wrong, please try again or contact us for help.');
+                    setIsDeleting(false);
+                },
+                onSuccess: () => {
+                    triggerSnackBar(false, 'Journal entry deletion successful!');
+                    if (date === moment().startOf('day').toISOString(true)) {
+                        window.scrollTo(0, 0);
+                    } else {
+                        setTimeout(() => {
+                            window.scrollTo(0, 0);
+                            navigate(`/journal/entries`);
+                        }, 1500);
+                    }
+                }
+            });
+        } else {
+            triggerSnackBar(true, 'Something went wrong, please try again or contact us for help.');
+        }
     };
 
     return (
@@ -221,6 +253,20 @@ const JournalEntryDisplay: React.FC<JournalEntryDisplayProps> = (props) => {
                         </EditButtonContainer>
                     </MoodSection>
                 </MoodContainer>
+                {id && 
+                    (<Box my={5}>
+                        <Typography variant="body1" mb={1}>Want to remove this journal entry?</Typography>
+                        <LoadingButton 
+                            loading={isDeleting}
+                            onClick={onDeleteClick}
+                            variant="contained" 
+                            color="warning"
+                            size="small"
+                        >
+                                Delete Entry
+                        </LoadingButton> 
+                    </Box>)
+                }
             </Box>
             <UpdateEntryModal 
                 isOpen={isUpdateEntryModalOpen}

--- a/src/pages/JournalPage/JournalPage.tsx
+++ b/src/pages/JournalPage/JournalPage.tsx
@@ -54,7 +54,8 @@ const JournalPage = () => {
                                 {data.map((entry: JournalEntry) => {
                                     return (
                                     <JournalEntryCard 
-                                        entry={entry} 
+                                        entry={entry}
+                                        email={user.email} 
                                         key={entry.id} 
                                     />)
                                 })}


### PR DESCRIPTION
What this PR does:
- Adds the functionality back for deleting a journal entry
- Adds the email prop to a journal entry card so that when the user selects the entry for "today" from the journal page, the user is navigated to the home page instead 
- Adds smooth scroll to top for when the user deletes an entry